### PR TITLE
Use contents of extracted war-File

### DIFF
--- a/jarlotte-mojo/src/main/scala/de/metacoder/jarlotte/JarPackagingMojoExecutor.scala
+++ b/jarlotte-mojo/src/main/scala/de/metacoder/jarlotte/JarPackagingMojoExecutor.scala
@@ -34,17 +34,20 @@ class JarPackagingMojoExecutor(mojo: JarPackagingMojo) {
 
     val targetDir = Paths.get(mojo.getProject.getBuild.getDirectory).toFile
     val projectFinalName: String = mojo.getProject.getBuild.getFinalName
-    val buildDir = Paths.get(mojo.getProject.getBuild.getDirectory, projectFinalName).toFile
+    val warFile = Paths.get(mojo.getProject.getBuild.getDirectory, s"$projectFinalName.war").toFile
+    val extractedWarDir = Paths.get(mojo.getProject.getBuild.getDirectory, "extracted-war-jarlotte", projectFinalName)
     val jarlotteZipFileName = s"$projectFinalName-jarlotte.jar"
 
-    if(!buildDir.exists()){
-      throw new MojoFailureException(s"Couldn't find target directory $targetDir. Please make sure that the maven war plugin ran in this phase before (order in xml matters, see effective pom in doubt)!")
+    if(!warFile.exists()){
+      throw new MojoFailureException(s"Couldn't find $warFile. Please make sure that the maven war plugin ran in this phase before (order in xml matters, see effective pom in doubt)!")
     }
+
+    new ZipFile(warFile).extractAll(extractedWarDir.toString)
 
     /* Step 1: Add WAR-Content to jar */
     val zipFile = new ZipFile(Paths.get(targetDir.getAbsolutePath, jarlotteZipFileName).toFile)
     val zipParameters = new ZipParameters
-    zipFile.addFolder(buildDir, zipParameters)
+    zipFile.addFolder(extractedWarDir.toFile, zipParameters)
 
     /* Step 2: Add Jarlotte stuff */
 

--- a/jarlotte-packagetest/pom.xml
+++ b/jarlotte-packagetest/pom.xml
@@ -16,6 +16,13 @@
 
         <plugins>
             <plugin>
+                <artifactId>maven-war-plugin</artifactId>
+                <configuration>
+                    <packagingExcludes>WEB-INF/classes/ignoredTestResource.txt</packagingExcludes>
+                </configuration>
+            </plugin>
+
+            <plugin>
                 <groupId>de.metacoder</groupId>
                 <artifactId>jarlotte-mojo</artifactId>
                 <version>${project.version}</version>

--- a/jarlotte-packagetest/src/main/resources/ignoredTestResource.txt
+++ b/jarlotte-packagetest/src/main/resources/ignoredTestResource.txt
@@ -1,0 +1,1 @@
+This file should not be packed in the jarlotte jar.


### PR DESCRIPTION
When using the Maven build output, files that are excluded from the war
packaging are included in the Jarlotte JAR.

Instead of using the Maven build output, the war-File is extracted and
its contents is used for packaging into the Jarlotte JAR now.

Thus, contents now equal the war file ones.
